### PR TITLE
Add ability to link 

### DIFF
--- a/THUNDERBIRD_README.md
+++ b/THUNDERBIRD_README.md
@@ -13,3 +13,5 @@ export LD_LIBRARY_PATH=$HOME/.local/opt/llvm@thunderbird/lib:$LD_LIBRARY_PATH
 export TBCLANG=$HOME/.local/opt/llvm@thunderbird/bin/clang
 $TBCLANG offload/test/offloading/offloading_success.c -fopenmp --offload-arch=thunderbird -S -o out.s
 ````
+
+NOTE: May need to add `-I$HOME/.local/opt/llvm@thunderbird/include` to the compilation script if `omp.h` is missing  

--- a/THUNDERBIRD_README.md
+++ b/THUNDERBIRD_README.md
@@ -14,4 +14,5 @@ export TBCLANG=$HOME/.local/opt/llvm@thunderbird/bin/clang
 $TBCLANG offload/test/offloading/offloading_success.c -fopenmp --offload-arch=thunderbird -S -o out.s
 ````
 
+````
 NOTE: May need to add `-I$HOME/.local/opt/llvm@thunderbird/include` to the compilation script if `omp.h` is missing  

--- a/THUNDERBIRD_README.md
+++ b/THUNDERBIRD_README.md
@@ -1,0 +1,14 @@
+# Building
+```
+```bash
+./scripts/build_thunderbird.sh --prefix /home/user/.local/opt/llvm@thunderbird --src ./ --jobs 12
+```
+
+# Compiling a Program
+```
+```bash
+export LD_LIBRARY_PATH=/Users/rkabrick/.local/opt/llvm@thunderbird/lib:$LD_LIBRARY_PATH
+export TBCLANG=/Users/rkabrick/.local/opt/llvm@thunderbird/bin/clang
+$TBCLANG offload/test/offloading/offloading_success.c -fopenmp --offload-arch=thunderbird -S -o out.s
+```
+

--- a/THUNDERBIRD_README.md
+++ b/THUNDERBIRD_README.md
@@ -1,17 +1,15 @@
 # Building
-```
+
+````
 ```bash
-./scripts/build_thunderbird.sh --prefix /home/user/.local/opt/llvm@thunderbird --src ./ --jobs 12
-```
+./scripts/build_thunderbird.sh --prefix $HOME/.local/opt/llvm@thunderbird --src ./ --jobs 12
+````
 
 # Compiling a Program
-```
+
+````
 ```bash
-export LD_LIBRARY_PATH=/Users/rkabrick/.local/opt/llvm@thunderbird/lib:$LD_LIBRARY_PATH
-export TBCLANG=/Users/rkabrick/.local/opt/llvm@thunderbird/bin/clang
+export LD_LIBRARY_PATH=$HOME/.local/opt/llvm@thunderbird/lib:$LD_LIBRARY_PATH
+export TBCLANG=$HOME/.local/opt/llvm@thunderbird/bin/clang
 $TBCLANG offload/test/offloading/offloading_success.c -fopenmp --offload-arch=thunderbird -S -o out.s
-```
-
-
-*NOTE*: Right now inside of ClangLinkerWrapper.cpp I have a hardcoded path to a path on my system. This will have to be changed if you want this to work. I have to change this to more portable likely with an environment variable or something.
-
+````

--- a/THUNDERBIRD_README.md
+++ b/THUNDERBIRD_README.md
@@ -12,3 +12,6 @@ export TBCLANG=/Users/rkabrick/.local/opt/llvm@thunderbird/bin/clang
 $TBCLANG offload/test/offloading/offloading_success.c -fopenmp --offload-arch=thunderbird -S -o out.s
 ```
 
+
+*NOTE*: Right now inside of ClangLinkerWrapper.cpp I have a hardcoded path to a path on my system. This will have to be changed if you want this to work. I have to change this to more portable likely with an environment variable or something.
+

--- a/THUNDERBIRD_README.md
+++ b/THUNDERBIRD_README.md
@@ -11,7 +11,7 @@
 ```bash
 export LD_LIBRARY_PATH=$HOME/.local/opt/llvm@thunderbird/lib:$LD_LIBRARY_PATH
 export TBCLANG=$HOME/.local/opt/llvm@thunderbird/bin/clang
-$TBCLANG offload/test/offloading/offloading_success.c -fopenmp --offload-arch=thunderbird -S -o out.s
+$TBCLANG offload/test/offloading/offloading_success.c -fopenmp --offload-arch=thunderbird -o offloading_success 
 ````
 
 ````

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -129,6 +129,38 @@ static std::optional<llvm::Triple> getOffloadTargetTriple(const Driver &D,
   return llvm::Triple(OffloadTargets[0]);
 }
 
+// Infer a device triple for OpenMP when users only pass --offload-arch=thunderbird.
+static std::optional<llvm::Triple>
+getThunderbirdOpenMPOffloadTargetTriple(const Driver &D,
+                                        const ArgList &Args,
+                                        const llvm::Triple &HostTriple) {
+  // If the user did NOT give -fopenmp-targets=..., try to deduce it from --offload-arch.
+  if (!Args.hasArg(options::OPT_offload_EQ)) {
+    auto Archs = Args.getAllArgValues(options::OPT_offload_arch_EQ);
+    // Single-arch or mixed-arch is OK; pick our triple if 'thunderbird' is requested.
+    if (llvm::is_contained(Archs, "thunderbird")) {
+      // Match host pointer width to choose rv32 vs rv64 (mirrors NVIDIA/HIP helpers).
+      return llvm::Triple(HostTriple.isArch64Bit()
+                              ? "riscv64-inspire-elf"
+                              : "riscv32-inspire-elf");
+    }
+    // No inference for other arch names.
+    return std::nullopt;
+  }
+
+  // If -fopenmp-targets was provided, validate and forward it as-is.
+  auto TT = getOffloadTargetTriple(D, Args);
+  if (!TT)
+    return std::nullopt;
+
+  // Accept any RISC-V triple here; the front-end will still enforce OpenMP support.
+  if (TT->isRISCV())
+    return TT;
+
+  D.Diag(diag::err_drv_invalid_or_unsupported_offload_target) << TT->str();
+  return std::nullopt;
+}
+
 static std::optional<llvm::Triple>
 getNVIDIAOffloadTargetTriple(const Driver &D, const ArgList &Args,
                              const llvm::Triple &HostTriple) {
@@ -1089,14 +1121,23 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
                ((!IsHIP && !IsCuda) || UseLLVMOffload)) {
       llvm::Triple AMDTriple("amdgcn-amd-amdhsa");
       llvm::Triple NVPTXTriple("nvptx64-nvidia-cuda");
+      const bool HostIs64 = C.getDefaultToolChain().getTriple().isArch64Bit();
+      llvm::Triple ThunderbirdTriple(HostIs64
+                                       ? "riscv64-inspire-elf"
+                                       : "riscv32-inspire-elf");
 
+      bool HasThunderbird = false;
       for (StringRef Arch :
            C.getInputArgs().getAllArgValues(options::OPT_offload_arch_EQ)) {
         bool IsNVPTX = IsNVIDIAOffloadArch(
             StringToOffloadArch(getProcessorFromTargetID(NVPTXTriple, Arch)));
         bool IsAMDGPU = IsAMDOffloadArch(
             StringToOffloadArch(getProcessorFromTargetID(AMDTriple, Arch)));
-        if (!IsNVPTX && !IsAMDGPU && !Arch.empty() &&
+        // RISC-V 'thunderbird' arch tag: accept exact match or future "thunderbird+..."
+        bool IsThunderbird = Arch.equals_insensitive("thunderbird") ||
+                           Arch.starts_with_insensitive("thunderbird");
+        HasThunderbird |= IsThunderbird;
+        if (!IsNVPTX && !IsAMDGPU && !IsThunderbird && !Arch.empty() &&
             !Arch.equals_insensitive("native")) {
           Diag(clang::diag::err_drv_failed_to_deduce_target_from_arch) << Arch;
           return;
@@ -1118,6 +1159,24 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
         }
       }
 
+    // Add a Thunderbird device toolchain if requested.
+    if (HasThunderbird) {
+      auto &TBTC = getOffloadToolChain(C.getInputArgs(), Action::OFK_OpenMP,
+                                       ThunderbirdTriple,
+                                       C.getDefaultToolChain().getTriple());
+      C.addOffloadDeviceToolChain(&TBTC, Action::OFK_OpenMP);
+      // We accept any 'thunderbird' tag; enumerate exactly what the user asked for.
+      llvm::SmallVector<StringRef> TBArchs;
+      for (StringRef A :
+           C.getInputArgs().getAllArgValues(options::OPT_offload_arch_EQ))
+        if (A.equals_insensitive("thunderbird") ||
+            A.starts_with_insensitive("thunderbird"))
+          TBArchs.push_back(A);
+      // If none were collected (defensive), still register a single 'thunderbird'.
+      if (TBArchs.empty())
+        TBArchs.push_back(StringRef("thunderbird"));
+      OffloadArchs[&TBTC] = TBArchs;
+    }
       // If the set is empty then we failed to find a native architecture.
       auto TCRange = C.getOffloadToolChains(Action::OFK_OpenMP);
       if (TCRange.first == TCRange.second)

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -130,35 +130,13 @@ static std::optional<llvm::Triple> getOffloadTargetTriple(const Driver &D,
 }
 
 // Infer a device triple for OpenMP when users only pass --offload-arch=thunderbird.
-static std::optional<llvm::Triple>
-getThunderbirdOpenMPOffloadTargetTriple(const Driver &D,
-                                        const ArgList &Args,
-                                        const llvm::Triple &HostTriple) {
-  // If the user did NOT give -fopenmp-targets=..., try to deduce it from --offload-arch.
-  if (!Args.hasArg(options::OPT_offload_EQ)) {
-    auto Archs = Args.getAllArgValues(options::OPT_offload_arch_EQ);
-    // Single-arch or mixed-arch is OK; pick our triple if 'thunderbird' is requested.
-    if (llvm::is_contained(Archs, "thunderbird")) {
-      // Match host pointer width to choose rv32 vs rv64 (mirrors NVIDIA/HIP helpers).
-      return llvm::Triple(HostTriple.isArch64Bit()
-                              ? "riscv64-inspire-elf"
-                              : "riscv32-inspire-elf");
-    }
-    // No inference for other arch names.
-    return std::nullopt;
-  }
-
-  // If -fopenmp-targets was provided, validate and forward it as-is.
-  auto TT = getOffloadTargetTriple(D, Args);
-  if (!TT)
-    return std::nullopt;
-
-  // Accept any RISC-V triple here; the front-end will still enforce OpenMP support.
-  if (TT->isRISCV())
-    return TT;
-
-  D.Diag(diag::err_drv_invalid_or_unsupported_offload_target) << TT->str();
-  return std::nullopt;
+// // Infer a device triple for OpenMP when users only pass --offload-arch=thunderbird.
+static llvm::Triple
+getThunderbirdTriple(const llvm::Triple &HostTriple) {
+  // Match host pointer width to choose rv32 vs rv64.
+  return llvm::Triple(HostTriple.isArch64Bit()
+                          ? "riscv64-inspire-elf"
+                          : "riscv32-inspire-elf");
 }
 
 static std::optional<llvm::Triple>
@@ -1126,6 +1104,8 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
                                        ? "riscv64-inspire-elf"
                                        : "riscv32-inspire-elf");
 
+      bool HasAMDGPU = false;
+      bool HasNVPTX = false;
       bool HasThunderbird = false;
       for (StringRef Arch :
            C.getInputArgs().getAllArgValues(options::OPT_offload_arch_EQ)) {
@@ -1136,7 +1116,10 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
         // RISC-V 'thunderbird' arch tag: accept exact match or future "thunderbird+..."
         bool IsThunderbird = Arch.equals_insensitive("thunderbird") ||
                            Arch.starts_with_insensitive("thunderbird");
+        HasAMDGPU |= IsAMDGPU;
+        HasNVPTX |= IsNVPTX;
         HasThunderbird |= IsThunderbird;
+
         if (!IsNVPTX && !IsAMDGPU && !IsThunderbird && !Arch.empty() &&
             !Arch.equals_insensitive("native")) {
           Diag(clang::diag::err_drv_failed_to_deduce_target_from_arch) << Arch;
@@ -1145,38 +1128,42 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
       }
 
       // Attempt to deduce the offloading triple from the set of architectures.
-      // We can only correctly deduce NVPTX / AMDGPU triples currently.
-      for (const llvm::Triple &TT : {AMDTriple, NVPTXTriple}) {
-        auto &TC = getOffloadToolChain(C.getInputArgs(), Action::OFK_OpenMP, TT,
-                                       C.getDefaultToolChain().getTriple());
+      if (HasAMDGPU || HasNVPTX) {
+        for (const llvm::Triple &TT : {AMDTriple, NVPTXTriple}) {
+          auto &TC = getOffloadToolChain(C.getInputArgs(), Action::OFK_OpenMP, TT,
+                                        C.getDefaultToolChain().getTriple());
 
-        llvm::SmallVector<StringRef> Archs =
-            getOffloadArchs(C, C.getArgs(), Action::OFK_OpenMP, &TC,
-                            /*SpecificToolchain=*/false);
-        if (!Archs.empty()) {
-          C.addOffloadDeviceToolChain(&TC, Action::OFK_OpenMP);
-          OffloadArchs[&TC] = Archs;
+          llvm::SmallVector<StringRef> Archs =
+              getOffloadArchs(C, C.getArgs(), Action::OFK_OpenMP, &TC,
+                              /*SpecificToolchain=*/false);
+          if (!Archs.empty()) {
+            C.addOffloadDeviceToolChain(&TC, Action::OFK_OpenMP);
+            OffloadArchs[&TC] = Archs;
+          }
         }
       }
 
-    // Add a Thunderbird device toolchain if requested.
-    if (HasThunderbird) {
-      auto &TBTC = getOffloadToolChain(C.getInputArgs(), Action::OFK_OpenMP,
-                                       ThunderbirdTriple,
-                                       C.getDefaultToolChain().getTriple());
-      C.addOffloadDeviceToolChain(&TBTC, Action::OFK_OpenMP);
-      // We accept any 'thunderbird' tag; enumerate exactly what the user asked for.
-      llvm::SmallVector<StringRef> TBArchs;
-      for (StringRef A :
-           C.getInputArgs().getAllArgValues(options::OPT_offload_arch_EQ))
-        if (A.equals_insensitive("thunderbird") ||
-            A.starts_with_insensitive("thunderbird"))
-          TBArchs.push_back(A);
-      // If none were collected (defensive), still register a single 'thunderbird'.
-      if (TBArchs.empty())
-        TBArchs.push_back(StringRef("thunderbird"));
-      OffloadArchs[&TBTC] = TBArchs;
-    }
+            if (HasThunderbird) {
+        // Call the helper function to get the correct triple.
+        const llvm::Triple ThunderbirdTriple =
+            getThunderbirdTriple(C.getDefaultToolChain().getTriple());
+
+        auto &TBTC = getOffloadToolChain(C.getInputArgs(), Action::OFK_OpenMP,
+                                         ThunderbirdTriple,
+                                         C.getDefaultToolChain().getTriple());
+        C.addOffloadDeviceToolChain(&TBTC, Action::OFK_OpenMP);
+        // We accept any 'thunderbird' tag; enumerate exactly what the user asked for.
+        llvm::SmallVector<StringRef> TBArchs;
+        for (StringRef A :
+             C.getInputArgs().getAllArgValues(options::OPT_offload_arch_EQ))
+          if (A.equals_insensitive("thunderbird") ||
+              A.starts_with_insensitive("thunderbird"))
+            TBArchs.push_back(A);
+        // If none were collected (defensive), still register a single 'thunderbird'.
+        if (TBArchs.empty())
+          TBArchs.push_back(StringRef("thunderbird"));
+        OffloadArchs[&TBTC] = TBArchs;
+      }
       // If the set is empty then we failed to find a native architecture.
       auto TCRange = C.getOffloadToolChains(Action::OFK_OpenMP);
       if (TCRange.first == TCRange.second)

--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -26,6 +26,7 @@ using namespace llvm::opt;
 static bool getArchFeatures(const Driver &D, StringRef Arch,
                             std::vector<StringRef> &Features,
                             const ArgList &Args) {
+
   bool EnableExperimentalExtensions =
       Args.hasArg(options::OPT_menable_experimental_extensions);
   auto ISAInfo =
@@ -69,7 +70,17 @@ static void getRISCFeaturesFromMcpu(const Driver &D, const Arg *A,
 void riscv::getRISCVTargetFeatures(const Driver &D, const llvm::Triple &Triple,
                                    const ArgList &Args,
                                    std::vector<StringRef> &Features) {
+  // For OpenMP offloading, if the user specified --offload-arch=thunderbird,
+  // override MArch with our specific architecture string.
   std::string MArch = getRISCVArch(Args, Triple);
+
+  if (Args.hasArg(options::OPT_fopenmp) &&
+      Args.hasArg(options::OPT_offload_arch_EQ)) {
+    auto Archs = Args.getAllArgValues(options::OPT_offload_arch_EQ);
+    if (llvm::is_contained(Archs, "thunderbird")) {
+      MArch = Triple.isArch64Bit() ? "rv64gc" : "rv32gc";
+    }
+  }
 
   if (!getArchFeatures(D, MArch, Features, Args))
     return;

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4404,7 +4404,7 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
             TT.getArch() == llvm::Triple::nvptx ||
             TT.getArch() == llvm::Triple::nvptx64 || TT.isAMDGCN() ||
             TT.getArch() == llvm::Triple::x86 ||
-            TT.getArch() == llvm::Triple::x86_64))
+            TT.getArch() == llvm::Triple::x86_64 || TT.isRISCV()))
         Diags.Report(diag::err_drv_invalid_omp_target) << A->getValue(i);
       else if (getArchPtrSize(T) != getArchPtrSize(TT))
         Diags.Report(diag::err_drv_incompatible_omp_arch)

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -465,7 +465,6 @@ namespace riscv64 {
 Expected<StringRef> link(ArrayRef<StringRef> InputFiles, const ArgList &Args,
                          uint16_t ActiveOffloadKindMask) {
   llvm::TimeTraceScope TimeScope("RISCV64 Link");
-  // Use `clang` to invoke the appropriate device tools.
   Expected<std::string> ClangPath =
       findProgram("clang", {getMainExecutable("clang")});
   if (!ClangPath)
@@ -487,7 +486,13 @@ Expected<StringRef> link(ArrayRef<StringRef> InputFiles, const ArgList &Args,
       "-o",
       *TempFileOrErr,
       Args.MakeArgString("--target=" + Triple.getTriple()),
-  };
+      // Don’t let the driver inject crt0.o, -lc, or compiler-rt builtins
+      "-nostdlib",
+      "-nodefaultlibs",
+      "-nostartfiles",
+      "-Wl,--gc-sections",
+      "-Wl,--no-undefined",
+   };
 
   CmdArgs.push_back("-fuse-ld=lld");
 
@@ -505,17 +510,11 @@ Expected<StringRef> link(ArrayRef<StringRef> InputFiles, const ArgList &Args,
   for (StringRef InputFile : InputFiles)
     CmdArgs.push_back(InputFile);
 
-  // add only the libraries needed for the RISC-V device.
-  if (!Triple.isGPU()) { // This condition is true for riscv64
-    CmdArgs.push_back("-Wl,-Bsymbolic");
-
-    // TODO: Change this to not be manual
-    CmdArgs.push_back("-L/Users/rkabrick/dev/resources/inspiresemi/thunderbird-llvm/thunderbird/devel/build-thunderbird/offload");
-    // TODO: Figure out what the correct way to link this is... either just lomptarget-rtl or the specific name
-    // CmdArgs.push_back("-lomptarget-rtl");
-    CmdArgs.push_back("-l:libomptarget.rtl.thunderbird.a");
-
-  }
+     if (!Triple.isGPU()) {
+      CmdArgs.push_back("-Wl,-Bsymbolic");
+      CmdArgs.push_back(Args.MakeArgString(
+          "-L" + StringRef("/Users/rkabrick/dev/resources/inspiresemi/thunderbird-llvm/thunderbird/devel/build-thunderbird/offload")));
+   }
 
   if (SaveTemps && linkerSupportsLTO(Args))
     CmdArgs.push_back("-Wl,--save-temps");

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -460,9 +460,8 @@ fatbinary(ArrayRef<std::pair<StringRef, StringRef>> InputFiles,
 }
 } // namespace amdgcn
 
-namespace riscv64 {
-// This function is a modified copy of generic::clang.
-Expected<StringRef> link(ArrayRef<StringRef> InputFiles, const ArgList &Args,
+namespace riscv64{
+   Expected<StringRef> link(ArrayRef<StringRef> InputFiles, const ArgList &Args,
                          uint16_t ActiveOffloadKindMask) {
   llvm::TimeTraceScope TimeScope("RISCV64 Link");
   Expected<std::string> ClangPath =
@@ -492,29 +491,34 @@ Expected<StringRef> link(ArrayRef<StringRef> InputFiles, const ArgList &Args,
       "-nostartfiles",
       "-Wl,--gc-sections",
       "-Wl,--no-undefined",
-   };
+  };
 
   CmdArgs.push_back("-fuse-ld=lld");
 
-  if (!Arch.empty())
-    CmdArgs.push_back(Args.MakeArgString("-march=" + Arch));
+  // Determine whether to pass -march or -mcpu based on the arch string.
+  auto IsRISCVISA = [](StringRef S) {
+    return S.starts_with("rv32") || S.starts_with("rv64");
+  };
+  if (!Arch.empty()) {
+    if (IsRISCVISA(Arch)) {
+      CmdArgs.push_back(Args.MakeArgString("-march=" + Arch));
+    } else if (Arch != "generic" && !Arch.ends_with("-host")) {
+      // Treat non-ISA token as CPU name (e.g., "thunderbird").
+      CmdArgs.push_back(Args.MakeArgString("-mcpu=" + Arch));
+    }
+  }
 
-  // Forward all of the `--offload-opt` and similar options to the device.
+  // Forward plugin/LTO options to the device linker plugin 
   for (auto &Arg : Args.filtered(OPT_offload_opt_eq_minus, OPT_mllvm))
-    CmdArgs.append(
-        {"-Xlinker",
-         Args.MakeArgString("--plugin-opt=" + StringRef(Arg->getValue()))});
-
-  CmdArgs.push_back("-Wl,--no-undefined");
+    CmdArgs.append({"-Xlinker",
+                    Args.MakeArgString("--plugin-opt=" + StringRef(Arg->getValue()))});
 
   for (StringRef InputFile : InputFiles)
     CmdArgs.push_back(InputFile);
 
-     if (!Triple.isGPU()) {
-      CmdArgs.push_back("-Wl,-Bsymbolic");
-      CmdArgs.push_back(Args.MakeArgString(
-          "-L" + StringRef("/Users/rkabrick/dev/resources/inspiresemi/thunderbird-llvm/thunderbird/devel/build-thunderbird/offload")));
-   }
+  if (!Triple.isGPU()) {
+    CmdArgs.push_back("-Wl,-Bsymbolic");
+  }
 
   if (SaveTemps && linkerSupportsLTO(Args))
     CmdArgs.push_back("-Wl,--save-temps");
@@ -532,7 +536,7 @@ Expected<StringRef> link(ArrayRef<StringRef> InputFiles, const ArgList &Args,
 
   return *TempFileOrErr;
 }
-} // namespace riscv64
+}
 
 namespace generic {
 Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -460,6 +460,81 @@ fatbinary(ArrayRef<std::pair<StringRef, StringRef>> InputFiles,
 }
 } // namespace amdgcn
 
+namespace riscv64 {
+// This function is a modified copy of generic::clang.
+Expected<StringRef> link(ArrayRef<StringRef> InputFiles, const ArgList &Args,
+                         uint16_t ActiveOffloadKindMask) {
+  llvm::TimeTraceScope TimeScope("RISCV64 Link");
+  // Use `clang` to invoke the appropriate device tools.
+  Expected<std::string> ClangPath =
+      findProgram("clang", {getMainExecutable("clang")});
+  if (!ClangPath)
+    return ClangPath.takeError();
+
+  const llvm::Triple Triple(Args.getLastArgValue(OPT_triple_EQ));
+  StringRef Arch = Args.getLastArgValue(OPT_arch_EQ);
+  // Create a new file to write the linked device image to.
+  auto TempFileOrErr =
+      createOutputFile(sys::path::filename(ExecutableName) + "." +
+                           Triple.getArchName() + "." + Arch,
+                       "img");
+  if (!TempFileOrErr)
+    return TempFileOrErr.takeError();
+
+  SmallVector<StringRef, 16> CmdArgs{
+      *ClangPath,
+      "--no-default-config",
+      "-o",
+      *TempFileOrErr,
+      Args.MakeArgString("--target=" + Triple.getTriple()),
+  };
+
+  CmdArgs.push_back("-fuse-ld=lld");
+
+  if (!Arch.empty())
+    CmdArgs.push_back(Args.MakeArgString("-march=" + Arch));
+
+  // Forward all of the `--offload-opt` and similar options to the device.
+  for (auto &Arg : Args.filtered(OPT_offload_opt_eq_minus, OPT_mllvm))
+    CmdArgs.append(
+        {"-Xlinker",
+         Args.MakeArgString("--plugin-opt=" + StringRef(Arg->getValue()))});
+
+  CmdArgs.push_back("-Wl,--no-undefined");
+
+  for (StringRef InputFile : InputFiles)
+    CmdArgs.push_back(InputFile);
+
+  // add only the libraries needed for the RISC-V device.
+  if (!Triple.isGPU()) { // This condition is true for riscv64
+    CmdArgs.push_back("-Wl,-Bsymbolic");
+
+    // TODO: Change this to not be manual
+    CmdArgs.push_back("-L/Users/rkabrick/dev/resources/inspiresemi/thunderbird-llvm/thunderbird/devel/build-thunderbird/offload");
+    // TODO: Figure out what the correct way to link this is... either just lomptarget-rtl or the specific name
+    // CmdArgs.push_back("-lomptarget-rtl");
+    CmdArgs.push_back("-l:libomptarget.rtl.thunderbird.a");
+
+  }
+
+  if (SaveTemps && linkerSupportsLTO(Args))
+    CmdArgs.push_back("-Wl,--save-temps");
+
+  if (Args.hasArg(OPT_embed_bitcode))
+    CmdArgs.push_back("-Wl,--lto-emit-llvm");
+
+  for (StringRef Arg : Args.getAllArgValues(OPT_linker_arg_EQ))
+    CmdArgs.append({"-Xlinker", Args.MakeArgString(Arg)});
+  for (StringRef Arg : Args.getAllArgValues(OPT_compiler_arg_EQ))
+    CmdArgs.push_back(Args.MakeArgString(Arg));
+
+  if (Error Err = executeCommands(*ClangPath, CmdArgs))
+    return std::move(Err);
+
+  return *TempFileOrErr;
+}
+} // namespace riscv64
+
 namespace generic {
 Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
                           uint16_t ActiveOffloadKindMask) {
@@ -593,6 +668,8 @@ Expected<StringRef> linkDevice(ArrayRef<StringRef> InputFiles,
   case Triple::systemz:
   case Triple::loongarch64:
     return generic::clang(InputFiles, Args, ActiveOffloadKindMask);
+  case Triple::riscv64:
+    return riscv64::link(InputFiles, Args, ActiveOffloadKindMask);
   default:
     return createStringError(Triple.getArchName() +
                              " linking is not supported");

--- a/scripts/build_thunderbird.sh
+++ b/scripts/build_thunderbird.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 usage() {
-  cat <<EOF
+	cat <<EOF
 Usage: $0 --prefix <install-prefix> [options]
 
 Options:
@@ -40,91 +40,91 @@ FFI_INC=""
 EXTRA_CMAKE=()
 
 while [[ $# -gt 0 ]]; do
-  case "$1" in
-  --src)
-    SRC_ROOT="$2"
-    shift 2
-    ;;
-  --prefix)
-    PREFIX="$2"
-    shift 2
-    ;;
-  --jobs)
-    JOBS="$2"
-    shift 2
-    ;;
-  --plugin)
-    PLUGIN="$2"
-    shift 2
-    ;;
-  --with-host)
-    WITH_HOST=1
-    shift
-    ;;
-  --skip-host)
-    SKIP_HOST=1
-    shift
-    ;;
-  --skip-libomp)
-    SKIP_LIBOMP=1
-    shift
-    ;;
-  --skip-offload)
-    SKIP_OFFLOAD=1
-    shift
-    ;;
-  --lit)
-    LIT_PATH="$2"
-    shift 2
-    ;;
-  --ffi-so)
-    FFI_SO="$2"
-    shift 2
-    ;;
-  --ffi-inc)
-    FFI_INC="$2"
-    shift 2
-    ;;
-  --cmake-arg)
-    EXTRA_CMAKE+=("$2")
-    shift 2
-    ;;
-  -h | --help)
-    usage
-    exit 0
-    ;;
-  *)
-    echo "Unknown arg: $1" >&2
-    usage >&2
-    exit 1
-    ;;
-  esac
+	case "$1" in
+	--src)
+		SRC_ROOT="$2"
+		shift 2
+		;;
+	--prefix)
+		PREFIX="$2"
+		shift 2
+		;;
+	--jobs)
+		JOBS="$2"
+		shift 2
+		;;
+	--plugin)
+		PLUGIN="$2"
+		shift 2
+		;;
+	--with-host)
+		WITH_HOST=1
+		shift
+		;;
+	--skip-host)
+		SKIP_HOST=1
+		shift
+		;;
+	--skip-libomp)
+		SKIP_LIBOMP=1
+		shift
+		;;
+	--skip-offload)
+		SKIP_OFFLOAD=1
+		shift
+		;;
+	--lit)
+		LIT_PATH="$2"
+		shift 2
+		;;
+	--ffi-so)
+		FFI_SO="$2"
+		shift 2
+		;;
+	--ffi-inc)
+		FFI_INC="$2"
+		shift 2
+		;;
+	--cmake-arg)
+		EXTRA_CMAKE+=("$2")
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "Unknown arg: $1" >&2
+		usage >&2
+		exit 1
+		;;
+	esac
 done
 
 [[ -n "$SRC_ROOT" && -n "$PREFIX" ]] || {
-  usage >&2
-  exit 1
+	usage >&2
+	exit 1
 } >&2
 
 need() { command -v "$1" >/dev/null || {
-  echo "Missing '$1'" >&2
-  exit 1
+	echo "Missing '$1'" >&2
+	exit 1
 }; }
 need cmake
 need ninja
 
 # ---- validate tree
 [[ -d "$SRC_ROOT/llvm" ]] || {
-  echo "Missing $SRC_ROOT/llvm" >&2
-  exit 1
+	echo "Missing $SRC_ROOT/llvm" >&2
+	exit 1
 }
 [[ -d "$SRC_ROOT/openmp" ]] || {
-  echo "Missing $SRC_ROOT/openmp" >&2
-  exit 1
+	echo "Missing $SRC_ROOT/openmp" >&2
+	exit 1
 }
 [[ -d "$SRC_ROOT/offload" ]] || {
-  echo "Missing $SRC_ROOT/offload" >&2
-  exit 1
+	echo "Missing $SRC_ROOT/offload" >&2
+	exit 1
 }
 
 # ---- build dirs
@@ -138,21 +138,22 @@ mkdir -p "$BUILD_ROOT"
 # Phase 1: host toolchain (LLVM + Clang + LLD)
 # ============================================================
 if [[ "$SKIP_HOST" -eq 0 ]]; then
-  echo "==> Phase 1: LLVM/Clang/LLD -> $PREFIX"
-  rm -rf "$PHASE1_BUILD"
-  declare -a CMAKE_PHASE1_ARGS=(
-    -S "$SRC_ROOT/llvm" -B "$PHASE1_BUILD" -G Ninja
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo
-    -DLLVM_ENABLE_ASSERTIONS=ON
-    -DLLVM_TARGETS_TO_BUILD="X86;RISCV"
-    -DLLVM_ENABLE_PROJECTS="clang;lld"
-    -DCMAKE_INSTALL_PREFIX="$PREFIX"
-    -DCMAKE_PARALLEL_LINK_JOBS=4
-  )
-  cmake "${CMAKE_PHASE1_ARGS[@]}"
-  ninja -C "$PHASE1_BUILD" -j"$JOBS" install
+	echo "==> Phase 1: LLVM/Clang/LLD -> $PREFIX"
+	rm -rf "$PHASE1_BUILD"
+	declare -a CMAKE_PHASE1_ARGS=(
+		-S "$SRC_ROOT/llvm" -B "$PHASE1_BUILD" -G Ninja
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo
+		-DLLVM_ENABLE_ASSERTIONS=ON
+		-DLLVM_TARGETS_TO_BUILD="Native;X86;RISCV"
+		-DLLVM_ENABLE_PROJECTS="clang;lld"
+		-DCMAKE_INSTALL_PREFIX="$PREFIX"
+		-DCMAKE_PARALLEL_LINK_JOBS=4
+
+	)
+	cmake "${CMAKE_PHASE1_ARGS[@]}"
+	ninja -C "$PHASE1_BUILD" -j"$JOBS" install
 else
-  echo "==> Phase 1: skipped"
+	echo "==> Phase 1: skipped"
 fi
 
 # ============================================================
@@ -160,103 +161,106 @@ fi
 # ============================================================
 LIBOMP_SO="$PREFIX/lib/libomp.so"
 if [[ "$(uname)" == "Darwin" ]]; then
-  LIBOMP_SO="$PREFIX/lib/libomp.dylib"
+	LIBOMP_SO="$PREFIX/lib/libomp.dylib"
 fi
 
 if [[ "$SKIP_LIBOMP" -eq 0 ]]; then
-  echo "==> Phase 2: libomp -> $PREFIX"
-  rm -rf "$PHASE2_BUILD"
-  mkdir -p "$PHASE2_BUILD"
-  cmake -S "$SRC_ROOT/openmp" -B "$PHASE2_BUILD" -G Ninja \
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-    -DLIBOMP_OMPT_SUPPORT=ON \
-    -DCMAKE_C_COMPILER="$PREFIX/bin/clang" \
-    -DCMAKE_CXX_COMPILER="$PREFIX/bin/clang++" \
-    -DCMAKE_INSTALL_PREFIX="$PREFIX"
-  ninja -C "$PHASE2_BUILD" -j"$JOBS" install
+	echo "==> Phase 2: libomp -> $PREFIX"
+	rm -rf "$PHASE2_BUILD"
+	mkdir -p "$PHASE2_BUILD"
+	cmake -S "$SRC_ROOT/openmp" -B "$PHASE2_BUILD" -G Ninja \
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DLIBOMP_OMPT_SUPPORT=ON \
+		-DCMAKE_C_COMPILER="$PREFIX/bin/clang" \
+		-DCMAKE_CXX_COMPILER="$PREFIX/bin/clang++" \
+		-DCMAKE_INSTALL_PREFIX="$PREFIX"
+	ninja -C "$PHASE2_BUILD" -j"$JOBS" install
 else
-  echo "==> Phase 2: skipped"
+	echo "==> Phase 2: skipped"
 fi
 
 [[ -f "$LIBOMP_SO" ]] || {
-  echo "FATAL: libomp not found at $LIBOMP_SO" >&2
-  exit 1
+	echo "FATAL: libomp not found at $LIBOMP_SO" >&2
+	exit 1
 }
 
 # ============================================================
 # Phase 3: stand-alone offload + next-gen plugin(s)
 # ============================================================
 if [[ "$SKIP_OFFLOAD" -eq 0 ]]; then
-  echo "==> Phase 3: offload (+ $PLUGIN${WITH_HOST:+;host}) -> $PREFIX"
-  rm -rf "$PHASE3_BUILD"
-  mkdir -p "$PHASE3_BUILD"
-  # Find libffi library and headers
-  if [[ -z "$FFI_SO" ]] && command -v pkg-config >/dev/null && pkg-config --exists libffi; then
-    echo "--> Found libffi via pkg-config"
-    FFI_INC="$(pkg-config --cflags-only-I libffi | sed -e 's/^-I//' -e 's/ .*//')"
-    # Use CMAKE_FIND_LIBRARY_SUFFIXES to let CMake find the right lib extension (.so, .dylib)
-    FFI_LIB_DIR="$(pkg-config --libs-only-L libffi | sed 's/^-L//')"
-    CMAKE_ARGS+=(-DFFI_LIBRARY_DIR="$FFI_LIB_DIR")
-  fi
+	echo "==> Phase 3: offload (+ $PLUGIN${WITH_HOST:+;host}) -> $PREFIX"
+	rm -rf "$PHASE3_BUILD"
+	mkdir -p "$PHASE3_BUILD"
+	# Find libffi library and headers
+	if [[ -z "$FFI_SO" ]] && command -v pkg-config >/dev/null && pkg-config --exists libffi; then
+		echo "--> Found libffi via pkg-config"
+		FFI_INC="$(pkg-config --cflags-only-I libffi | sed -e 's/^-I//' -e 's/ .*//')"
+		# Use CMAKE_FIND_LIBRARY_SUFFIXES to let CMake find the right lib extension (.so, .dylib)
+		FFI_LIB_DIR="$(pkg-config --libs-only-L libffi | sed 's/^-L//')"
+		CMAKE_ARGS+=(-DFFI_LIBRARY_DIR="$FFI_LIB_DIR")
+	fi
 
-  # If user provided headers, use them. Otherwise, use what pkg-config found.
-  if [[ -n "$FFI_INC" ]]; then
-    CMAKE_ARGS+=(-DFFI_INCLUDE_DIR="$FFI_INC")
-  fi
-  # If user provided the full shared lib path, use it.
-  if [[ -n "$FFI_SO" ]]; then
-    CMAKE_ARGS+=(-DFFI_LIBRARY="$FFI_SO")
-  fi
+	# If user provided headers, use them. Otherwise, use what pkg-config found.
+	if [[ -n "$FFI_INC" ]]; then
+		CMAKE_ARGS+=(-DFFI_INCLUDE_DIR="$FFI_INC")
+	fi
+	# If user provided the full shared lib path, use it.
+	if [[ -n "$FFI_SO" ]]; then
+		CMAKE_ARGS+=(-DFFI_LIBRARY="$FFI_SO")
+	fi
 
-  # Some branches don’t propagate -lffi from libomptarget to tools; add -lffi to link flags.
-  CMAKE_LINKER_FLAGS="-L$PREFIX/lib -lffi"
+	# Some branches don’t propagate -lffi from libomptarget to tools; add -lffi to link flags.
+	CMAKE_LINKER_FLAGS="-L$PREFIX/lib -lffi"
 
-  PLUGINS="$PLUGIN"
-  [[ $WITH_HOST -eq 1 ]] && PLUGINS="$PLUGINS;host"
-  CMAKE_ARGS=(
-    -G Ninja "$SRC_ROOT/offload"
-    -DOPENMP_STANDALONE_BUILD=ON
-    -DLIBOMPTARGET_PLUGINS_TO_BUILD="$PLUGINS"
-    -DLIBOMPTARGET_FORCE_"$(echo "$PLUGIN" | tr '[:lower:]' '[:upper:]')"_TESTS=ON
-    -DLLVM_ENABLE_ASSERTIONS=ON
-    -DLLVM_DIR="$PREFIX/lib/cmake/llvm"
-    -DOPENMP_LLVM_TOOLS_DIR="$PREFIX/bin"
-    -DCMAKE_PREFIX_PATH="$PREFIX"
-    -DCMAKE_C_COMPILER="$PREFIX/bin/clang"
-    -DCMAKE_CXX_COMPILER="$PREFIX/bin/clang++"
-    -DCMAKE_ASM_COMPILER="$PREFIX/bin/clang"
-    -DCMAKE_INSTALL_PREFIX="$PREFIX"
-    -DLIBOMP_STANDALONE="$LIBOMP_SO"
-    -DCMAKE_EXE_LINKER_FLAGS="$CMAKE_LINKER_FLAGS"
-    -DCMAKE_SHARED_LINKER_FLAGS="$CMAKE_LINKER_FLAGS"
-    -DFFI_INCLUDE_DIR="$FFI_INC"
-    -DCMAKE_ASM_COMPILER="$PREFIX/bin/clang"
-  )
+	PLUGINS="$PLUGIN"
+	[[ $WITH_HOST -eq 1 ]] && PLUGINS="$PLUGINS;host"
+	CMAKE_ARGS=(
+		-G Ninja "$SRC_ROOT/offload"
+		-DOPENMP_STANDALONE_BUILD=ON
+		-DLIBOMPTARGET_PLUGINS_TO_BUILD="$PLUGINS"
+		-DLIBOMPTARGET_FORCE_"$(echo "$PLUGIN" | tr '[:lower:]' '[:upper:]')"_TESTS=ON
+		# In your CMake configuration for Phase 3, add:
+		-DLIBOMPTARGET_BUILD_DEVICERTL_BCLIB=ON
+		-DLIBOMPTARGET_DEVICE_ARCHITECTURES="riscv64"
+		-DLLVM_ENABLE_ASSERTIONS=ON
+		-DLLVM_DIR="$PREFIX/lib/cmake/llvm"
+		-DOPENMP_LLVM_TOOLS_DIR="$PREFIX/bin"
+		-DCMAKE_PREFIX_PATH="$PREFIX"
+		-DCMAKE_C_COMPILER="$PREFIX/bin/clang"
+		-DCMAKE_CXX_COMPILER="$PREFIX/bin/clang++"
+		-DCMAKE_ASM_COMPILER="$PREFIX/bin/clang"
+		-DCMAKE_INSTALL_PREFIX="$PREFIX"
+		-DLIBOMP_STANDALONE="$LIBOMP_SO"
+		-DCMAKE_EXE_LINKER_FLAGS="$CMAKE_LINKER_FLAGS"
+		-DCMAKE_SHARED_LINKER_FLAGS="$CMAKE_LINKER_FLAGS"
+		-DFFI_INCLUDE_DIR="$FFI_INC"
+		-DCMAKE_ASM_COMPILER="$PREFIX/bin/clang"
+	)
 
-  # Optional tests
-  if [[ -n "$LIT_PATH" ]]; then
-    CMAKE_ARGS+=(-DOPENMP_LLVM_LIT_EXECUTABLE="$LIT_PATH")
-  fi
+	# Optional tests
+	if [[ -n "$LIT_PATH" ]]; then
+		CMAKE_ARGS+=(-DOPENMP_LLVM_LIT_EXECUTABLE="$LIT_PATH")
+	fi
 
-  # Extra args
-  CMAKE_ARGS+=("${EXTRA_CMAKE[@]}")
+	# Extra args
+	CMAKE_ARGS+=("${EXTRA_CMAKE[@]}")
 
-  cmake -S "$SRC_ROOT/offload" -B "$PHASE3_BUILD" "${CMAKE_ARGS[@]}"
+	cmake -S "$SRC_ROOT/offload" -B "$PHASE3_BUILD" "${CMAKE_ARGS[@]}"
 
-  # Build the shared runtime + helper tools
-  ninja -C "$PHASE3_BUILD" -j"$JOBS" omptarget llvm-offload-device-info llvm-omp-kernel-replay
-  ninja -C "$PHASE3_BUILD" install
+	# Build the shared runtime + helper tools
+	ninja -C "$PHASE3_BUILD" -j"$JOBS" omptarget llvm-offload-device-info llvm-omp-kernel-replay
+	ninja -C "$PHASE3_BUILD" install
 
-  # Show helper paths
-  DEVINFO_BIN="$(find "$PHASE3_BUILD" -type f -name llvm-offload-device-info -perm -111 | head -n1 || true)"
-  KREPLAY_BIN="$(find "$PHASE3_BUILD" -type f -name llvm-omp-kernel-replay -perm -111 | head -n1 || true)"
+	# Show helper paths
+	DEVINFO_BIN="$(find "$PHASE3_BUILD" -type f -name llvm-offload-device-info -perm -111 | head -n1 || true)"
+	KREPLAY_BIN="$(find "$PHASE3_BUILD" -type f -name llvm-omp-kernel-replay -perm -111 | head -n1 || true)"
 
-  echo
-  echo "==> Helpers:"
-  echo "  device-info : ${DEVINFO_BIN:-<not found>}"
-  echo "  kernel-replay: ${KREPLAY_BIN:-<not found>}"
+	echo
+	echo "==> Helpers:"
+	echo "  device-info : ${DEVINFO_BIN:-<not found>}"
+	echo "  kernel-replay: ${KREPLAY_BIN:-<not found>}"
 else
-  echo "==> Phase 3: skipped"
+	echo "==> Phase 3: skipped"
 fi
 
 echo

--- a/scripts/build_thunderbird.sh
+++ b/scripts/build_thunderbird.sh
@@ -109,7 +109,7 @@ done
 need() { command -v "$1" >/dev/null || {
   echo "Missing '$1'" >&2
   exit 1
-} }
+}; }
 need cmake
 need ninja
 
@@ -147,6 +147,7 @@ if [[ "$SKIP_HOST" -eq 0 ]]; then
     -DLLVM_TARGETS_TO_BUILD="X86;RISCV"
     -DLLVM_ENABLE_PROJECTS="clang;lld"
     -DCMAKE_INSTALL_PREFIX="$PREFIX"
+    -DCMAKE_PARALLEL_LINK_JOBS=4
   )
   cmake "${CMAKE_PHASE1_ARGS[@]}"
   ninja -C "$PHASE1_BUILD" -j"$JOBS" install


### PR DESCRIPTION
This pull request makes it possible to run:

`clang offload/test/offloading/offloading_success.c -fopenmp --offload-arch=thunderbird -o offloading_success` 

and generate a binary for `host` that has offload sections compiled for riscv64gc (ie. thunderbird)